### PR TITLE
add cmd deserialize

### DIFF
--- a/src/kaleidoscope/deserialize.rs
+++ b/src/kaleidoscope/deserialize.rs
@@ -1,0 +1,25 @@
+use kaleidoscope::{Config, RGBSubCommand};
+use clap::ArgMatches;
+use database::Database;
+use jsonrpc::client::Client;
+use std::fs;
+use rgb::proof::Proof;
+use std::io::Read;
+
+pub struct Deserialize {}
+
+impl<'a> RGBSubCommand<'a> for Deserialize {
+	fn run(matches: &'a ArgMatches<'a>, config: &Config, database: &mut Database, client: &mut Client) -> Result<(), jsonrpc::Error> {
+		use bitcoin::network::serialize::deserialize;
+		let path = matches.value_of("path").unwrap();
+		println!("Deserializing proof at {}", path);
+		let mut file = fs::File::open(path).unwrap();
+		let mut buffer: Vec<u8> = Vec::new();
+
+		file.read_to_end(&mut buffer);
+
+		let decoded: Proof = deserialize(&mut buffer).unwrap();
+		println!("Proof at {} deserialized succesfully", path);
+		Ok(())
+	}
+}

--- a/src/kaleidoscope/mod.rs
+++ b/src/kaleidoscope/mod.rs
@@ -12,6 +12,7 @@ pub mod sendtoaddress;
 pub mod getnewaddress;
 pub mod sync;
 pub mod burn;
+pub mod deserialize;
 
 pub trait RGBSubCommand<'a> {
     fn run(matches: &'a ArgMatches<'a>, config: &Config, database: &mut Database, client: &mut jsonrpc::client::Client) -> Result<(), jsonrpc::Error>;

--- a/src/main.rs
+++ b/src/main.rs
@@ -17,6 +17,7 @@ use kaleidoscope::listunspent::ListUnspent;
 use kaleidoscope::RGBSubCommand;
 use kaleidoscope::sendtoaddress::SendToAddress;
 use kaleidoscope::sync::Sync;
+use kaleidoscope::deserialize::Deserialize;
 
 pub mod kaleidoscope;
 pub mod database;
@@ -113,6 +114,12 @@ fn main() {
                 .value_name("AMOUNT")
                 .required(true)
                 .help("Set the amount")))
+        .subcommand(SubCommand::with_name("deserialize")
+            .about("Deserialize a proof")
+            .arg(Arg::with_name("path")
+                .value_name("PATH")
+                .required(true)
+                .help("the path to the proof")))
         .get_matches();
 
     let default_rgb_dir = home_dir().unwrap().join(".rgb");
@@ -137,6 +144,8 @@ fn main() {
         GetNewAddress::run(&sub_matches, &config, &mut database, &mut client);
     } else if let Some(sub_matches) = matches.subcommand_matches("sync") {
         Sync::run(&sub_matches, &config, &mut database, &mut client);
+    } else if let Some(sub_matches) = matches.subcommand_matches("deserialize") {
+        Deserialize::run(&sub_matches, &config, &mut database, &mut client);
     } else {
         println!("{}", matches.usage());
     }


### PR DESCRIPTION
```
$ ./target/debug/kaleidoscope help deserialize
kaleidoscope-deserialize
Deserialize a proof

USAGE:
    kaleidoscope deserialize <PATH>

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

ARGS:
    <PATH>    the path to the proof
```